### PR TITLE
Removed a note for tenancy:install

### DIFF
--- a/docs/hyn/5.x/installation.md
+++ b/docs/hyn/5.x/installation.md
@@ -26,7 +26,3 @@ Now enable the tenancy environment by running the installation procedure;
 ```bash
 php artisan tenancy:install
 ```
-
-> The `tenancy:install` command migrates the system tables and writes a `tenancy.json` into
-your Laravel installation path. This will tell the package that it is enabled. Remove
-that file in case you need to do a fresh installation.


### PR DESCRIPTION
New versions do not create tenancy.json file anymore so this part was irrelevant and misleading.