### PR TITLE
Fix composer installation

### DIFF
--- a/docs/hyn/5.2/installation.md
+++ b/docs/hyn/5.2/installation.md
@@ -62,7 +62,7 @@ configuring this connection may cause unwanted behaviour.
 Run the composer command to add the tenancy package as dependency:
 
 ```bash
-composer require hyn/multi-tenant:5.2.*
+composer require "hyn/multi-tenant:5.2.*"
 ```
 
 Laravel offers [package auto discovery][3]


### PR DESCRIPTION
The installation must provide with quotes, bash interprets `*` as part of the command, enclosing it will help readers.