### PR TITLE
Typo in spatie-laravel-permission.md

### DIFF
--- a/docs/hyn/5.1/spatie-laravel-permission.md
+++ b/docs/hyn/5.1/spatie-laravel-permission.md
@@ -33,7 +33,7 @@ to be tenant aware.
 next to your `User.php`. Make sure that these files extend `Spatie\Permission\Models\Permission::class` 
 and `Spatie\Permission\Models\Role::class` respectively.
 
-`App\Permission.php` - extends from `SpatieRole` and uses the `UsesTenantConnection` trait.
+`App\Permission.php` - extends from `SpatiePermission` and uses the `UsesTenantConnection` trait.
 ```php
 <?php
 


### PR DESCRIPTION
I noticed that "SpatiePermission" should be used instead of "SpatieRole".