### PR TITLE
[5.4] Doc updates for clarity and consistency

### DIFF
--- a/docs/hyn/5.4/cache.md
+++ b/docs/hyn/5.4/cache.md
@@ -49,5 +49,5 @@ allows you to set a custom cache driver in `config/cache.php`:
 ],
 ```
 
-> Make sure the CacheServiceProvider is registered in `config/app.php`. Or your driver will not be
-available for use.
+> Make sure the CacheServiceProvider is registered in `config/app.php` or else your driver will 
+not be available for use.

--- a/docs/hyn/5.4/commands.md
+++ b/docs/hyn/5.4/commands.md
@@ -18,8 +18,8 @@ $ php artisan tenancy:run --help
 
 How it works:
 
-- Using the `--tenant` option is optional, if you leave it out the command will be run on all tenants.
-- Tenant option --tenant accepts either single website id or comma separated list of website ids. 
+- Using the `--tenant` option is optional. If you leave it out the command will be run on all tenants.
+- The `--tenant` option accepts either a single website id or a comma separated list of website ids. 
 - If your target command requires options or arguments, you can add them like this:
 
 ```bash
@@ -49,12 +49,12 @@ Artisan::call('tenancy:run', [
         '--tenant' => [1,2,3]
         ]);
 ```
-> Make sure --tenant value is always an array, an integer value will fail.
+> Make sure --tenant value is always an array. An integer value will fail.
 
 # Recreate command
 
 The recreate command allows you to create databases and filesystem directories for
-all tenants. It will check whether a database already exists, if not it will recreate
+all tenants. It will check whether a database already exists, and if not it will recreate
 it and dispatch a "Created" event that causes the folders and possible vhost configurations
 to be made.
 
@@ -64,7 +64,7 @@ $ php artisan tenancy:recreate
 
 # Tenant Aware Tinker Command
 
-This article describes how to enable tenant awareness for the native Laravel tinker command.
+This section describes how to enable tenant awareness for the native Laravel `tinker` command.
 
 First, create a trait named `MutatesTinkerCommand` with the following content:
 
@@ -133,7 +133,7 @@ trait MutatesTinkerCommand
     }
 }
 ```
-You can only tinker on one database at a time, therefore, the `website_id` needs to be a required option. Utilizing the `AddWebsiteFilterOnCommand` trait available in the Tenancy package would not work in this instance; it is tailored to run processes on multiple websites and makes the `website_id` parameter optional.
+You can only tinker on one database at a time. Therefore the `website_id` needs to be a required option. Utilizing the `AddWebsiteFilterOnCommand` trait available in the Tenancy package would not work in this instance as it is tailored to run processes on multiple websites and makes the `website_id` parameter optional.
 
 Second, create a new console command `TinkerCommand` that uses the trait above.
 
@@ -176,7 +176,7 @@ class Kernel extends ConsoleKernel
 }
 ```
 
-Now we have created a new `tenancy:tinker` artisan command. The `tenancy:tinker` requires the `--website_id=` option as a parameter. So, in order to run tinker on, let’s say with a `website_id` of 1, you’ll need to run:
+Now we have created a new `tenancy:tinker` artisan command. The `tenancy:tinker` requires the `--website_id=` option as a parameter. So, in order to run tinker on a `website_id` of 1, you’ll need to run:
 
 ```bash
 $ php artisan tenancy:tinker --website_id=1

--- a/docs/hyn/5.4/commands.md
+++ b/docs/hyn/5.4/commands.md
@@ -54,8 +54,8 @@ Artisan::call('tenancy:run', [
 # Recreate command
 
 The recreate command allows you to create databases and filesystem directories for
-all tenants. It will check whether a database already exists, and if not it will recreate
-it and dispatch a "Created" event that causes the folders and possible vhost configurations
+all tenants. It will check whether each tenant database already exists, create it if necessary
+and then dispatch a "Created" event that causes the folders and possible vhost configurations
 to be made.
 
 ```bash

--- a/docs/hyn/5.4/commands.md
+++ b/docs/hyn/5.4/commands.md
@@ -151,31 +151,6 @@ class TinkerCommand extends BaseCommand
 }
 ```
 
-Third, add the `TinkerCommand` to your Console Kernel `$commands` array.
-
-```php
-<?php
-
-namespace App\Console;
-
-use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-use App\Console\Tinker\TinkerCommand;
-
-class Kernel extends ConsoleKernel
-{
-    /**
-     * The Artisan commands provided by your application.
-     *
-     * @var array
-     */
-    protected $commands = [
-        TinkerCommand::class,
-    ];
-    // ...
-}
-```
-
 Now we have created a new `tenancy:tinker` artisan command. The `tenancy:tinker` requires the `--website_id=` option as a parameter. So, in order to run tinker on a `website_id` of 1, you’ll need to run:
 
 ```bash

--- a/docs/hyn/5.4/concepts.md
+++ b/docs/hyn/5.4/concepts.md
@@ -10,17 +10,17 @@ on a server and serving multiple tenants. The interpretation of such a tenancy
 application is quite diverse.
 
 Hyn tenancy is focused on providing a drop-in solution for Laravel without
-sacrificing flexibility or hacks of the Laravel ecosystem.
+sacrificing flexibility or requiring extensive hacks of the Laravel ecosystem.
 
 Make sure you understand that the `Website` model is the subject of tenancy.
 
 The default method for identifying such a tenant website is by using the requested
-domain aka hostname. Taking a URL `http://yourdomain.com/foo/bar` only `yourdomain.com`
+domain aka `hostname`. Taking a URL `http://yourdomain.com/foo/bar` only `yourdomain.com`
 is taken into account although modifications to this logic is easy to implement. The
 `yourdomain.com` part of the URL is called a Fully Qualified Domain Name or `fqdn` for short.
  
 A website can have zero or more hostnames connected to it. This allows for easier
-attachment of additional hostnames or serving, for instance, an ad campaign page
+attachment of additional hostnames or serving, for instance an ad campaign page,
 on different domains.
 
 # Website
@@ -38,8 +38,8 @@ matching hostname or falls back to the default one.
 
 # Runtime
 
-By default, the package will identify the current requested hostname and bind it
-into the `Hyn\Tenancy\Contracts\CurrentHostname` contract. In case that hostname belongs to
+By default, the package will identify the current requested `hostname` and bind it
+into the `Hyn\Tenancy\Contracts\CurrentHostname` contract. In case that `hostname` belongs to
 a website, the latter will be bound into the `Hyn\Tenancy\Contracts\Tenant` contract. Whenever
 a Tenant is identified or switched the package will automatically infuse additional functionality
 into Laravel, including [global tenant routes][routes], [tenant overrides][directory-structure] 

--- a/docs/hyn/5.4/configuration.md
+++ b/docs/hyn/5.4/configuration.md
@@ -18,12 +18,13 @@ I've listed some of the basic settings below.
 
 ## tenancy.php
 
-The tenancy configuration file holds every setting related to tenants. This includes how to generate a unique
-website, but also how database connections are set up. In addition, it allows for;
+The `tenancy.php` configuration file holds every setting related to tenants. 
+This includes how to generate a unique website, but also how database connections are set up. 
+In addition, it allows for:
 
-- custom random id logic.
-- manual tenant identification.
-- on what disk (see `config/filesystems.php`) to store the tenant-specific files.
+- custom random id logic
+- manual tenant identification
+- on what disk (see `config/filesystems.php`) to store the tenant-specific files
 - specifying tenant database division mode
 - specifying the password generator
 - specifying the migrations path
@@ -36,10 +37,10 @@ website, but also how database connections are set up. In addition, it allows fo
 
 ## webserver.php
 
-With the webserver.php one can more closely fine tune integration of this package with your webserver.
+The `webserver.php` configuration file allows one to more closely fine tune integration of this package with your webserver.
 Ports, vhost configuration files and the location to save these files are all contained in this config.
 
-In general you can expect the following settings for each webserver;
+The settings in this configuration file are:
 
 - enabled; whether the service is enabled and thus the package will write files for it and reload the service.
 - ports; which ports we should use, this is required to configure the vhost files properly.

--- a/docs/hyn/5.4/connections.md
+++ b/docs/hyn/5.4/connections.md
@@ -16,15 +16,15 @@ If for some reason you need to create an Eloquent Model that would need to conne
 to the system connection, you can apply the `Hyn\Tenancy\Traits\UsesSystemConnection`
 trait on your given Model. In doing so, the model’s connection will always default to use the `system`.
 
-One reason for using the `system` connection is when you have data which you'd like
-to share between all tenants or which you need to influence the tenant identification
+One reason for using the `system` connection is for storing data which you'd like
+to share between all tenants or which you need to use to influence the tenant identification
 process. For instance when you are creating an admin portal that would manage all of your
 tenants in one place.
 
 ## Tenant Connection
 This is maybe the most used database connection. Data in use by single tenant instances,
-not shared with others, is persisted into the database using the tenant connection. The
-implementation of the tenant connection ensures that no tenant can access another tenants data.
+not shared with others, is persisted into the database using the `tenant` connection. The
+implementation of the `tenant` connection ensures that no tenant can access another tenant's data.
 
 By using the `Hyn\Tenancy\Traits\UsesTenantConnection` trait, the package will make sure
 that it is using the right database connection.
@@ -61,6 +61,6 @@ The password of the tenant is generated using several components mashed up as md
 - Website UUID.
 - Website created_at.
 
-In case you wish to change/update the `tenancy.key` we added a useful command `tenancy:key:update`
+In case you wish to change/update the `tenancy.key` we provide a useful command `tenancy:key:update`
 which will update the tenant password with the new md5 value. This allows for easier key rotation.
 

--- a/docs/hyn/5.4/creating-tenants.md
+++ b/docs/hyn/5.4/creating-tenants.md
@@ -4,7 +4,7 @@ icon: fal fa-dolly-flatbed
 ---
 
 Tenancy is heavily driven by events. For event listeners to properly work, you
-have to use the repositories to create new websites and hostnames.
+have to use the provided repositories to create new websites and hostnames.
 
 # Create website
 
@@ -27,9 +27,9 @@ The UUID is used for the database username and database name. In addition
 I'd recommend using this unique string for every public facing URL, eg
 an admin dashboard.
 
-By default tenancy will create a `uuid` automatically
-using a UUID generator, you can replace that class in the 
-`tenancy.php > website > random-id-generator`, make sure it implements
+By default this package will create a `uuid` automatically
+using a UUID generator. You can replace that class in the 
+`tenancy.php > website > random-id-generator`, as long as it implements
 `Hyn\Tenancy\Contracts\Website\UuidGenerator`.
 
 If you want to force your own UUID for the website, without creating a full
@@ -39,7 +39,7 @@ it to the repository.
 ```php
 $website = new Website;
 // Implement custom random hash using Laravels Str::random
-$website->uuid = str_random(10);
+$website->uuid = Str::random(10);
 app(WebsiteRepository::class)->create($website);
 dd($website->uuid); // Random string of length 10
 ```
@@ -86,7 +86,7 @@ Fully Qualified Domain Name and can be something like `yourapp.com` or
 # Switch to new tenant
 
 For the package to set up Laravel for the specific tenant, the environment has to be
-"switched". This switching will set up amongst other the tenant database connection and
+"switched". This switching will set up things like the tenant database connection and
 filesystem logic like custom config files.
 
 ```php
@@ -111,4 +111,4 @@ In case you would like to query the database for hostnames or websites. Use the
 `query()` method of the repositories, this will return a [`Illuminate\Database\Eloquent\Builder`][query-builder]
 instance.
 
-[query-builder]: https://laravel.com/docs/5.6/queries
+[query-builder]: https://laravel.com/docs/5.8/queries

--- a/docs/hyn/5.4/events.md
+++ b/docs/hyn/5.4/events.md
@@ -5,8 +5,7 @@ icon: fal fa-hourglass-end
 
 To create a fluid ecosystem around Laravel, this package uses events heavily.
 
-> It's highly recommended to read up on the native [events][laravel-events] by Laravel
-in case you are unaware about its purposes.
+> It's highly recommended to read up on the native [events][laravel-events] in Laravel.
 
 # Model events
 
@@ -15,8 +14,7 @@ Namespaces:
 - `Hyn\Tenancy\Events\Hostnames`
 - `Hyn\Tenancy\Events\Websites`
 
-All of the models have the following events per default, these should be
-self explanatory.
+All of the models have the following events, whose purposes mirror Laravel's own model events.
 
 - Creating
 - Created
@@ -38,7 +36,7 @@ Namespace: `Hyn\Tenancy\Events\Websites`.
 
 Namespace: `Hyn\Tenancy\Events\Hostnames`.
 
-The hostname models has a few additional events:
+The hostname model has a few additional events:
 
 - Attached: the hostname was attached to a website.
 - Detached: the hostname was removed from a website.
@@ -71,4 +69,4 @@ Namespace: `Hyn\Tenancy\Events\Webservers`.
 
 - ConfigurationSaved: the configuration for the webserver was saved to disk.
 
-[laravel-events]: https://laravel.com/docs/5.6/events
+[laravel-events]: https://laravel.com/docs/5.8/events

--- a/docs/hyn/5.4/fallback.md
+++ b/docs/hyn/5.4/fallback.md
@@ -27,12 +27,12 @@ enabled, all routes contained in that file will automatically override any decla
 from `routes/web.php` or `routes/api.php`. Make sure to apply the proper middleware to those routes.
 
 In case you enable `tenancy.routes.replace-global` all previously declared routes
-will be removed and replaced with the contents of the tenants.php routes file.
+will be removed and replaced with the contents of the `routes/tenants.php` file.
 
 > Understand unlike the default `web.php` and `api.php` files no group is set around this file. You need
 to apply your own `namespace`, `middleware` and other group settings inside the `tenants.php`.
 
-An example `tenants.php` file:
+An example `routes/tenants.php` file:
 
 ```php
 <?php

--- a/docs/hyn/5.4/filesystem.md
+++ b/docs/hyn/5.4/filesystem.md
@@ -35,7 +35,7 @@ the same methods you are used to, including; `get`, `put` and `setVisibility`.
 
 # Tenancy directory
 
-In case you prefer having a higher level access to the files for tenants. You can use the Filesystem bound to Laravel's container.
+In case you prefer having a higher level access to the files for tenants you can use the Filesystem bound to Laravel's container.
 
 ```php
 /** @var \Illuminate\Contracts\Filesystem\Filesystem $tenancy */

--- a/docs/hyn/5.4/filesystem.md
+++ b/docs/hyn/5.4/filesystem.md
@@ -3,8 +3,7 @@ title: Filesystem
 icon: fal fa-hdd
 ---
 
-You are now, most likely, aware about the [directory structure][directory-structure]
-available to tenants. 
+Tenancy offers a strategic [directory structure][directory-structure] for tenants. 
 
 # Tenant disk
 
@@ -36,8 +35,7 @@ the same methods you are used to, including; `get`, `put` and `setVisibility`.
 
 # Tenancy directory
 
-In case you prefer having a higher level access to the files for tenants. You can use the ioc bound
-Filesystem.
+In case you prefer having a higher level access to the files for tenants. You can use the Filesystem bound to Laravel's container.
 
 ```php
 /** @var \Illuminate\Contracts\Filesystem\Filesystem $tenancy */
@@ -45,4 +43,4 @@ $tenancy = app('tenancy.disk');
 ```
 
 [directory-structure]: structure
-[laravel-filesystem]: https://laravel.com/docs/5.6/filesystem
+[laravel-filesystem]: https://laravel.com/docs/5.8/filesystem

--- a/docs/hyn/5.4/identification.md
+++ b/docs/hyn/5.4/identification.md
@@ -5,11 +5,11 @@ icon: fal fa-street-view
 
 During runtime, the `Environment` class is bound into Laravel's container. The
 tenancy environment holds one single responsibility, which is telling our code
-what hostname was currently identified and resolving the related website.
+what `hostname` is currently identified and resolving the related website.
 
 # Early identification
 
-By default tenancy will identify the tenant after all Middleware has been processed.
+By default Tenancy will identify the tenant after all Middleware has been processed.
 One could simply resolve the Environment class through the service container
 inside a middleware to force identification of the tenant early on. If you want the 
 package to handle this on your behalf you can now simply enable the `early-identification` flag in
@@ -41,7 +41,7 @@ execution. Use a background job to run mass changes on tenant databases.
 
 # Retrieve current tenant
 
-In case you like to work with the current environment, you can do the following:
+To work with the current environment, you can do the following:
 
 ```php
  

--- a/docs/hyn/5.4/installation.md
+++ b/docs/hyn/5.4/installation.md
@@ -6,7 +6,7 @@ icon: fal fa-arrow-alt-to-bottom
 
 # Elevated database user
 
-Tenancy requires a system connection that allows creating new databases for her
+Tenancy requires a `system` connection that allows creating new databases for
 tenants. In order to do so, we need to have a database user with elevated
 permissions.
 
@@ -28,8 +28,8 @@ CREATE USER tenancy WITH CREATEDB CREATEROLE PASSWORD 'someRandomPassword';
 GRANT ALL PRIVILEGES ON DATABASE tenancy to tenancy WITH GRANT OPTION;
 ```
 
-Make sure you configure this user as your system connection in your `database.php`.
-Under connections:
+Make sure you configure this user as your `system` connection in your `database.php`.
+Under `connections`:
 
 ```php
 'system' => [
@@ -48,9 +48,9 @@ Under connections:
 ]
 ```
 
-Most often it makes sense to use either `system` or `tenant` as your default database connection setting; this is `DB_CONNECTION` in your `.env` file. This environment variable is assigned to the `default` key in the `config/database.php` configuration file.
+Most often it makes sense to use either `system` or `tenant` as your default database connection setting. For example, Laravel assigns the value from `DB_CONNECTION` in your `.env` file to the `default` key in the `config/database.php` configuration file.
 
-In case you use the `tenant` make sure to enable [early identification](identification) and configure
+In case you use `tenant` make sure to enable [early identification](identification) and configure
 a decent [fallback](fallback) later on.
 
 > There is no need to configure the `tenant` connection in the `database.php`
@@ -65,11 +65,9 @@ Run the composer command to add the tenancy package as dependency:
 composer require "hyn/multi-tenant:5.4.*"
 ```
 
-Laravel offers [package auto discovery][3]
-in version 5.6. So that's all you need to do; no need to register any
-service providers manually in your `config/app.php`.
+Laravel's [package auto discovery][3] will register the service provider automatically.
 
-Publish the configuration files and migrations for tenancy, which allows you
+Publish the configuration files and migrations for Tenancy, which allow you
 to configure the behavior of the package.
 
 ```bash

--- a/docs/hyn/5.4/logging.md
+++ b/docs/hyn/5.4/logging.md
@@ -3,8 +3,8 @@ title: Logging
 icon: fal fa-book
 ---
 
-Especially in production you might want to split the default laravel log by tenants.
-Tenancy ships with a custom tenant aware logger which you can register in the logger config.
+Especially in production you might want to split the default Laravel log by tenants.
+Tenancy ships with a custom tenant aware logger which you can register in the `logging.php` config.
 
 - If a tenant is detected it will create a `logs` folder within the tenant directory:
 `storage/app/tenancy/tenants/<tenant uuid>/logs/<log_level>_<YYYY>-<MM>-<DD>.log`

--- a/docs/hyn/5.4/middleware.md
+++ b/docs/hyn/5.4/middleware.md
@@ -4,11 +4,11 @@ icon: fal fa-shield-alt
 excerpt: Automatic actions per tenant
 ---
 This package offers additional automation to make your life easier. Using
-middleware, you can mutate how specific requests are handled.
+middleware you can mutate how specific requests are handled.
 
 # Maintenance
 
-Set the property `under_maintenance_since` of the hostname to show a
+Set the property `under_maintenance_since` of the `hostname` to show a
 Laravel generic maintenance page.
 
 # Redirection
@@ -18,7 +18,7 @@ requests to this hostname.
 
 # Secure
 
-Set the property `force_https` to true to force all connections on this
+Set the property `force_https` to `true` to force all connections on this
 hostname to be handled using a SSL encrypted connection.
 
 # Abort

--- a/docs/hyn/5.4/migrations.md
+++ b/docs/hyn/5.4/migrations.md
@@ -3,9 +3,8 @@ title: Migrations
 icon: fal fa-pallet-alt
 ---
 
-Migrations are extremely important in the Laravel ecosystem. To facilitate
-tenants with this flow, without interfering with its logic migration commands
-for tenants have been given their own namespace `tenancy:`.
+Migrations are extremely important in the Laravel ecosystem. 
+Migration commands for tenants have the Artisan prefix `tenancy:`.
 
 # About the database/migrations path
 
@@ -20,7 +19,7 @@ The migrations for the system database can stay in `database/migrations`.
 
 If you want new tenants to be migrated by default, you can easily do so. In
 your `tenancy.php` configuration set `db > tenant-migrations-path` to a valid
-absolute path and all your new tenants will run these migrations per default.
+absolute path and all your new tenants will run these migrations by default.
 
 ```php
   // ..
@@ -33,12 +32,12 @@ absolute path and all your new tenants will run these migrations per default.
 In case you would also like to seed the databases of your newly created
 and migrated tenants, you can enable `db > tenant-seed-class` in your `tenancy.php`
 configuration file. Change this setting to a fully namespaced class name
-and the package will automatically run this seed after it has ran the
+and the package will automatically run this seed after it has run the
 automatic migrations.
 
 # Migration related commands
 
-Obviously tenancy is also able to run migrations running through artisan.
+Tenancy is also able to run migrations through Artisan commands.
 
 Tenancy has added the `--website_id[=WEBSITE_ID]` option to each of the following native Laravel migrate and seed
 command and namespaced it accordingly, for instance.
@@ -49,21 +48,21 @@ command and namespaced it accordingly, for instance.
 - `tenancy:migrate:rollback` - Rollback the last database migration
 - `tenancy:db:seed` - Seed the database with records
 
-The --website_id optional option accepts multiple values. Though optional, but if you leave the option out it will 
-run the command against all tenant. For example:
+The --website_id optional option accepts multiple values. Though optional, if you leave the option out it will 
+run the command against all tenants. For example:
 
 - `php artisan tenancy:migrate --website_id=1` to migrate just tenant website 1.
 - `php artisan tenancy:migrate --website_id=1 --website_id=2` to migrate tenant website 1 & 2.
 - `php artisan tenancy:migrate` to migrate all tenant websites.
 
-> The website_id reflects the auto incremented `id` column of the Website and **NOT** the UUID.
+> The `website_id` reflects the auto incremented `id` column of the Website and **NOT** the UUID.
 
 Please check the separate signatures for more information of valid arguments
 and options.
 
-> Running tenancy:migrate without any path or realpath option and
-without having configured tenant-migrations-path will migrate your 
-tenants with the files inside the database/migrations directory. 
+> Running `tenancy:migrate` without any path or realpath option and
+without having configured `tenant-migrations-path` will migrate your 
+tenants with the files inside the `database/migrations` directory. 
 
 # Reconstructing tenant databases
 

--- a/docs/hyn/5.4/models.md
+++ b/docs/hyn/5.4/models.md
@@ -3,11 +3,11 @@ title: Models
 icon: fal fa-hand-holding-box
 ---
 
-For you to more easily connect with the correct database a few ways are possible.
+Tenancy offers a few ways to more easily connect with the correct database.
 
 #### Traits
 
-Two traits exist to force a model onto either the tenant or system connection.
+Two traits exist to force a model onto either the `tenant` or `system` connection.
 
 - `Hyn\Tenancy\Traits\UsesSystemConnection` to make a model use the system connection.
 - `Hyn\Tenancy\Traits\UsesTenantConnection` to make a model use the tenant connection.
@@ -32,7 +32,7 @@ class User extends Authenticatable
 
 #### Abstract models
 
-Instead of using the traits one can also simply have the models extend the abstract
+Instead of using the traits directly one can also simply have the models extend the abstract
 models provided in the package.
 
 - `Hyn\Tenancy\Abstracts\SystemModel` can be extended to give easy access to 
@@ -40,7 +40,7 @@ the system database connection.
 - `Hyn\Tenancy\Abstracts\TenantModel` can be extended to have your Eloquent models 
 use the connection of the identified tenant per default.
 
-> Please note these models are using their respective traits.
+> Please note these abstract models are using the respective traits mentioned above.
 
 #### Relationships
 

--- a/docs/hyn/5.4/nginx.md
+++ b/docs/hyn/5.4/nginx.md
@@ -6,8 +6,8 @@ icon: fal fa-server
 # Set up
 
 You need to set up your own PHP FPM. The preferred way of running php is through a [socket][setup-socket] by
-configuring the `listen` value in your pool correctly. Make sure to copy the path to your
-sock and update your `webserver.php` configuration file in your app to reflect that value, for instance:
+configuring the `listen` value in your pool correctly. Make sure to copy the path of your
+sock and update your `webserver.php` configuration file to reflect that value, for instance:
 
 ```php
     /**

--- a/docs/hyn/5.4/queues.md
+++ b/docs/hyn/5.4/queues.md
@@ -3,9 +3,9 @@ title: Queues
 icon: fal fa-conveyor-belt
 ---
 
-One of the strongest features of Laravel are its queues. One drawback of sending
+One of the strongest features of Laravel is its queues. One drawback of sending
 Jobs into the Queue is that these are executed in a completely different process
-depending on your queue configuration including redis and beanstalk.
+depending on your queue configuration, including redis and beanstalk.
 
 In order to assist you with tenant aware jobs, this package automatically identifies
 whether a tenant website is active before processing the job. This ensures that

--- a/docs/hyn/5.4/requirements.md
+++ b/docs/hyn/5.4/requirements.md
@@ -9,9 +9,7 @@ icon: fal fa-clipboard-check
 - Optionally Apache 2.4+ or Nginx 1.12+.
 - [Applied experience with Laravel](#experience).
 
-> Please note that MySQL limits username and database length to 32, 
-enable in the `tenancy.php` configuration file:  `website > uuid-limit-length-to-32`
-to fix this.
+> Please note that MySQL limits username and database length to 32. Enable this in the `tenancy.php` configuration file:  `website > uuid-limit-length-to-32` to accommodate this.
 
 ## Experience
 

--- a/docs/hyn/5.4/spatie-laravel-permission.md
+++ b/docs/hyn/5.4/spatie-laravel-permission.md
@@ -7,6 +7,9 @@ tags:
     - permission
     - tutorial
 ---
+## Prerequisite
+You need a fresh Laravel app with Hyn Multi-Tenant installed. Briefly here are the basics:
+
 1. Create a fresh install of Laravel.  If you have installed the Laravel Terminal Installer run: `$ laravel new app`
 2. `$ cd app`
 3. Install `hyn/multi-tenant` package by running:
@@ -16,15 +19,15 @@ composer require hyn/multi-tenant
 4. Follow the instructions until "Deploy configuration" section.
 5. If you are using MySQL DB, you need to add the entry `LIMIT_UUID_LENGTH_32=true` in your `.env` file.
 
-## Install Spatie Permissions
+## Install Spatie Permissions Package
 
 To install the package follow the entire installation section
 at [GitHub - spatie/laravel-permission: Associate users with roles and permissions](https://github.com/spatie/laravel-permission#installation).
 
 ## Integration
 
-This section of the tutorial assumes that you have successfully created at least 2 hostnames
-and successfully have accessed them via your local environment setup.
+This section of the tutorial assumes that you have successfully [created at least 2 hostnames](creating-tenants)
+and have successfully accessed them via your local environment setup.
 
 We need to extend the two eloquent models (`Permission`, `Role`) of the Permissions
 package so that we can add the necessary changes we need in order for these two models
@@ -99,10 +102,9 @@ class User extends Authenticatable
 }
 ```
 
-3. Modify your `config/permission.php` file and modify the permission and role models
-that is being used here to point to your newly created models. e.g. `App\Permission::class`
+3. Modify your `config/permission.php` file and modify the `permission` and `role` models to point to your newly created models. e.g. `App\Permission::class`
 
-`config\permisssion.php`
+`config\permission.php`
 ```php
 <?php
 
@@ -120,7 +122,7 @@ return [
 ];
 ```
 
-4. Creating a user in your first hostname.
+4. Creating a user in your first hostname. (We're using the first hostname here merely as an example.)
 
 ```php
 <?php
@@ -143,11 +145,10 @@ $permission = Permission::create(['name' => 'edit articles']);
 $user = User::find(1);
 $user->getRoleNames();
 
-// Assign writer role and save the $user instance to DB.
+// Assign writer role
 $user->assignRole('writer');
-$user->save();
 
-// Requery and check if the newly assigned roles exists.
+// Requery and see that the newly assigned roles exists.
 $user = User::find(1);
 $user->getRoleNames();
 ```

--- a/docs/hyn/5.4/spatie-medialibrary.md
+++ b/docs/hyn/5.4/spatie-medialibrary.md
@@ -7,17 +7,14 @@ tags:
     - medialibrary
     - tutorial
 ---
-1. Create a fresh install of Laravel 5.7.  If you have installed the Laravel Terminal Installer run: 
+1. Create a fresh install of Laravel.  If you have installed the Laravel Terminal Installer run: 
 
 ```bash
 $ laravel new app
 ```
 
 2. `$ cd app`
-3. Install `hyn/multi-tenant` package by running:
-```bash
-$ composer require hyn/multi-tenant
-```
+3. Install `hyn/multi-tenant` package by running: `composer require hyn/multi-tenant`
 4. Follow the instructions until the "Deploy configuration" section.
 5. If you are using MySQL as a database, make sure to add the entry `LIMIT_UUID_LENGTH_32=true` in your `.env` file.
 
@@ -33,7 +30,7 @@ Publish the migration with:
 $ php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="migrations"
 ```
 
-Move the migration file from `database/migrations/2018_10_10_085035_create_media_table.php` to `database/migrations/tenant/`.
+Move the migration file (`2018_10_10_085035_create_media_table.php`) from `database/migrations/` to `database/migrations/tenant/`.
 
 After the migration has been published you can create the media-table in your tenant databases by running the migrations:
 ```bash
@@ -48,13 +45,13 @@ $ php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryService
 ## Integration
 
 This section of the tutorial assumes that you have successfully [created at least 2 hostnames](creating-tenants)
-and successfully have accessed them via your local environment setup.
+and have successfully accessed them via your local environment setup.
 
 We need to extend the `Media` eloquent model of the Medialibrary package so that we can add the
-necessary changes we need in order for these two models to be tenant aware.
+necessary changes for these two models to be tenant aware.
 
-1. Create a Media.php file and place them inside your `app` directory,
-next to your `User.php`. Make sure that these files extend `Spatie\MediaLibrary\Models\Media::class`.
+1. Create a Media.php file and place it inside your `app` directory,
+next to your `User.php`. Make sure that this class extends `Spatie\MediaLibrary\Models\Media::class`.
 
 `App\Media.php` - extends from `SpatieMedia` and uses the `UsesTenantConnection` trait.
 ```php
@@ -73,7 +70,7 @@ class Media extends SpatieMedia
 
 2. Prepare your model
 
-To associate media with a model, the tenant aware model must implement the following interface and trait:
+To associate media with a model, the tenant aware model must implement the following interface and traits, as shown below:
 
 ```php
 <?php
@@ -92,7 +89,7 @@ class User extends Model implements HasMedia
 }
 ```
 
-3. Modify your `config/medialibrary.php` file and modify the `media_model` that is being used here to point to your newly created model. e.g. `App\Media::class`
+3. Modify your `config/medialibrary.php` file and modify the `media_model` to point to your newly created model. e.g. `App\Media::class`
 
 `config\medialibrary.php`
 ```php

--- a/docs/hyn/5.4/structure.md
+++ b/docs/hyn/5.4/structure.md
@@ -10,19 +10,19 @@ file under `website > disk`. By default tenant files
 are stored in `storage/app/tenancy/tenants`.
 
 Inside this tenant directory you are able to override global logic by
-generating the necessary files. Check the tenancy configuration file under
+generating the necessary files. Check the `config/tenancy.php` file under
 `folders` to see which ones are enabled by default.
 
 ## Config
 
-Any php files stored inside a `config/` directory of the tenant is read
+Any php files stored inside a `config/` directory of the tenant are read
 during runtime. Existing configuration values are replaced and new ones
 are appended.
 
 A great use case for this feature is the ability to configure client 
 specific mail settings.
 
-The tenancy configuration file allows you to refuse overrides of specific
+The `config/tenancy.php` configuration file allows you to refuse overrides of specific
 configuration settings using the `folders > config > blacklist` setting.
 By default it disallows database, tenancy and webserver changes.
 
@@ -34,8 +34,8 @@ url's will be matched for this specific tenant only.
 
 ## Trans
 
-New translations can be easily added by creating a `lang/` folder.
-The native Laravel translator will parse any files contained within
+New translations can be added easily by creating a `lang/` folder.
+The native Laravel translator will parse any files contained here
 to be used in the application of this specific tenant.
 
 You are able to specify whether these language files should override
@@ -71,16 +71,16 @@ The media folder can be used by creating a `media/` folder inside the
 tenant directory. Files inside that directory will become automatically
 available as a public directory inside an equally named directory `media/`.
 
-Eg, storing a file `media/bg.jpg` will allow you to use `/media/bg.jpg` inside
+Eg: storing a file `media/bg.jpg` will allow you to use `/media/bg.jpg` inside
 your html. This applies to any file you store.
 
-## /media webserver
+### /media webserver
 
 An alias is set up binding the private tenant media directory to the public
 media directory. This is implemented using the auto generated web server
 configuration files for apache and nginx.
 
-## /media fallback controller
+### /media fallback controller
 
 In case you're not using the webserver vhost configuration files provided
 by this package you can choose to map the `MediaController` to the path, eg:

--- a/docs/hyn/5.4/validation.md
+++ b/docs/hyn/5.4/validation.md
@@ -10,8 +10,8 @@ Among all the built-in validation in Laravel, only the [exists](https://laravel.
 We can leverage these two rules with tenancy by adding the connection parameter. Both use the same validation rule
 signature which is `rule:connection.table,column`.
 
-So for example, to use `Exists (Database)` use `'email' => 'exists:tenant.staff,email'`. Where `tenant` is the `'tenant-connection-name'` you specified in your `tenancy.php` config file.
+So for example, to use `Exists (Database)` use `'email' => 'exists:tenant.staff,email'` where `tenant` is the `'tenant-connection-name'` you specified in your `tenancy.php` config file.
 
-You can change the `exists` keyword to `unique` to use the `unique` rule instead, eg: `'email' => 'unique:tenant.staff,email'`.
+Similarly, you can substitute the `exists` keyword to `unique` to use the `unique` rule instead, eg: `'email' => 'unique:tenant.staff,email'`.
 
 > Validating against the system database is possible using the method described above but replacing `tenant` with `system`.


### PR DESCRIPTION
While reviewing this package to try it out on a new project I read through the documentation and found a few opportunities to improve clarity. In the end I decided to review the whole lot. Some changes are tiny (comma replaces colon, `are` replaces `is`, etc), and others fix up the meaning slightly. In some cases I removed several words that weren't needed, thus simplifying.

@luceos I know this is a large PR, and for that I apologize; however I figured that since the time required to review is the same as with individual PRs, and this keeps all the changes together for easier viewing, I chose a single PR.

In some cases I capitalized `Tenancy` where it was referring to this package, and not to a `tenant`. There are more cases where that could be done, but I felt like I should clear that with you before going berserk with that.

While reviewing, if you have a strong opinion different from my proposals here, feel free to just edit directly here in github. I'm happy to make changes as requested, but if it's simpler for you to just make the edit rather than try to explain a desired change, just go ahead. (That said, if I'm really wrong on something I'd like to know, since maybe there's an opportunity for us both in that.)

Thanks again for this great package. It's come a long way since when I first looked at it. I'm excited to see what's in store with `tenancy/tenancy`.