### PR TITLE
Remove unnecessary words

### DIFF
--- a/docs/hyn/5.4/identification.md
+++ b/docs/hyn/5.4/identification.md
@@ -10,9 +10,9 @@ what `hostname` is currently identified and resolving the related website.
 # Early identification
 
 By default Tenancy will identify the tenant after all Middleware has been processed.
-One could simply resolve the Environment class through the service container
+You can resolve the Environment class through the service container
 inside a middleware to force identification of the tenant early on. If you want the 
-package to handle this on your behalf you can simply enable the `early-identification` flag in
+package to handle this on your behalf you can enable the `early-identification` flag in
  your `tenancy.php` configuration file under `hostname`.
 
 # Manual identification

--- a/docs/hyn/5.4/identification.md
+++ b/docs/hyn/5.4/identification.md
@@ -12,7 +12,7 @@ what `hostname` is currently identified and resolving the related website.
 By default Tenancy will identify the tenant after all Middleware has been processed.
 One could simply resolve the Environment class through the service container
 inside a middleware to force identification of the tenant early on. If you want the 
-package to handle this on your behalf you can now simply enable the `early-identification` flag in
+package to handle this on your behalf you can simply enable the `early-identification` flag in
  your `tenancy.php` configuration file under `hostname`.
 
 # Manual identification


### PR DESCRIPTION
Removing the word "now" since this has been available since at least `5.1`.
This reduces confusion when reading, wondering "since when?"