### PR TITLE
Set correct package name

### DIFF
--- a/docs/tenancy/1.x/database-driver-mysql.md
+++ b/docs/tenancy/1.x/database-driver-mysql.md
@@ -12,7 +12,7 @@ tags:
 Install using composer:
 
 ```bash
-$ composer require tenancy/database-driver-mysql
+$ composer require tenancy/db-driver-mysql
 ```
 
 ## Configuration


### PR DESCRIPTION
Change the package name from tenancy/database-driver-mysql to tenancy/db-driver-mysql