### PR TITLE
Update help file for commands

### DIFF
--- a/docs/hyn/5.4/commands.md
+++ b/docs/hyn/5.4/commands.md
@@ -22,8 +22,13 @@ How it works:
 - The `--tenant` option accepts either a single website id or a comma separated list of website ids. 
 - If your target command requires options or arguments, you can add them like this:
 
+To use arguments and options with values
 ```bash
 $ php artisan tenancy:run <command> --option="key=value" --option="live=1" --argument="key=value"
+```
+To use options without values i.e. --force you need to include = with empty value
+```bash
+$ php artisan tenancy:run <command> --option="force="
 ```
 > Make sure you include the argument or option key!
 


### PR DESCRIPTION
Added help file how to run options with values. 

Right now if you run option with just the name you get "Undefined offset: 1".  Maybe this should be fixed so that we check if option has value and if it doesn't we just take it as option without value i.e.

--force