### PR TITLE
Removed instruction to publish vendor files

### DIFF
--- a/docs/tenancy/1.x/database-driver-mysql.md
+++ b/docs/tenancy/1.x/database-driver-mysql.md
@@ -17,11 +17,6 @@ $ composer require tenancy/db-driver-mysql
 
 ## Configuration
 
-Publish the `db-driver-mysql.php` config file using artisan.
-
-```bash
-$ php artisan vendor:publish --tag db-driver-mysql
-```
 There are several ways of setting the tenant database configuration
 for MySQL:
 


### PR DESCRIPTION
ArlonAntonius suggested in discord chat that:
> We removed the publishable config as we found a better way of doing it.