### PR TITLE
Fix typos

### DIFF
--- a/docs/tenancy/1.x/affects-routes.md
+++ b/docs/tenancy/1.x/affects-routes.md
@@ -30,11 +30,11 @@ In the example we will register the routes for a Tenant if one is identified.
 
 namespace App\Listeners;
 
-use Tenancy\Affects\Routes\Events\ConfigureRoutes;
+use Tenancy\Affects\Routes\Events\ConfiguresRoutes;
 
 class TenantRoutes 
 {
-    public function handle(ConfigureRoutes $event) 
+    public function handle(ConfiguresRoutes $event) 
     {
         if($event->event->tenant)
         {


### PR DESCRIPTION
Fix from :

```php
...
use Tenancy\Affects\Routes\Events\ConfigureRoutes;

class TenantRoutes 
{
    public function handle(ConfigureRoutes $event) 
...
```

to :

```php
...
use Tenancy\Affects\Routes\Events\ConfiguresRoutes;

class TenantRoutes 
{
    public function handle(ConfiguresRoutes $event) 
...
```