### PR TITLE
Fix NothingIdentified Listener class name

### DIFF
--- a/docs/tenancy/1.x/identification-general.md
+++ b/docs/tenancy/1.x/identification-general.md
@@ -149,7 +149,7 @@ namespace App\Listeners;
 
 use Tenancy\Identification\Events\NothingIdentified;
 
-class TenantRoutes 
+class NoTenantIdentified 
 {
     public function handle(NothingIdentified $event) 
     {


### PR DESCRIPTION
Fixed the name of the listener in the "nothingIdentified" example.