### PR TITLE
Update hooks-hostname.md

### DIFF
--- a/docs/tenancy/1.x/hooks-hostname.md
+++ b/docs/tenancy/1.x/hooks-hostname.md
@@ -100,7 +100,7 @@ class SimpleHandler implements HostnameHandler
 {
     public function handle(Event $event): void
     {
-        if($this->hasValidDomains($event->tenant)){
+        if(!$this->hasValidDomains($event->tenant)){
         Mail::to($event->tenant->email)->send(new DomainsNotValid($event->tenant->getHostnames()));
         }
     }


### PR DESCRIPTION
https://tenancy.dev/docs/tenancy/1.x/hooks-hostname#handlers

According to the documentation:
"If the tenant **does not have valid domains**, we will send an email to the administrator regarding the domains not being valid."

Exclamation has been added to the _if_ condition to make the above statement valid.